### PR TITLE
refactor(task): remove redundant taskType field from Task and subclasses

### DIFF
--- a/data/LennyData.txt
+++ b/data/LennyData.txt
@@ -1,1 +1,1 @@
-T | 1 | buy book
+T | 0 | go home

--- a/src/main/java/lenny/logic/task/Deadline.java
+++ b/src/main/java/lenny/logic/task/Deadline.java
@@ -18,11 +18,13 @@ public class Deadline extends Task {
      */
     public Deadline(String taskName, String rawDeadline, Boolean isDone) {
         super(taskName);
-        this.setTaskType("D");
         this.deadline = DateFormatter.format(rawDeadline);
         this.setIsDone(isDone);
     }
 
+    public String getTaskType() {
+        return "D";
+    }
     /**
      * Returns the deadline string.
      *

--- a/src/main/java/lenny/logic/task/Event.java
+++ b/src/main/java/lenny/logic/task/Event.java
@@ -20,10 +20,13 @@ public class Event extends Task {
      */
     public Event(String taskName, String fromRaw, String toRaw , Boolean isDone) {
         super(taskName);
-        this.setTaskType("E");
         this.from = DateFormatter.format(fromRaw);
         this.to = DateFormatter.format(toRaw);
         this.setIsDone(isDone);
+    }
+
+    public String getTaskType() {
+        return "E";
     }
 
     /**

--- a/src/main/java/lenny/logic/task/Task.java
+++ b/src/main/java/lenny/logic/task/Task.java
@@ -8,7 +8,6 @@ package lenny.logic.task;
 public class Task {
     private String taskName;
     private Boolean isDone;
-    private String taskType;
 
     /**
      * Creates a new Task.
@@ -19,16 +18,9 @@ public class Task {
         this.taskName = taskName;
         isDone = false;
     }
-
-    /**
-     * Returns the type of the task as a string symbol.
-     *
-     * @return "T", "D", or "E" if the task type is Todo,Deadline or Event respectively.
-     */
     public String getTaskType() {
-        return taskType;
+        return "T";
     }
-
     /**
      * Returns whether this task is completed.
      *
@@ -55,9 +47,6 @@ public class Task {
         this.isDone = isDone;
     }
 
-    public void setTaskType(String taskType) {
-        this.taskType = taskType;
-    }
 
     /**
      * Marks this task as done.

--- a/src/main/java/lenny/logic/task/Todo.java
+++ b/src/main/java/lenny/logic/task/Todo.java
@@ -13,8 +13,11 @@ public class Todo extends Task {
      */
     public Todo(String taskName, Boolean isDone) {
         super(taskName);
-        this.setTaskType("T");
         this.setIsDone(isDone);
+    }
+
+    public String getTaskType() {
+        return "T";
     }
 
     @Override


### PR DESCRIPTION
- Derive type via subclass (`getTaskType()`) instead of stored state
- Eliminates duplication/mismatch risk; no functional behavior changes